### PR TITLE
Add Ability to Display Videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.zip
 *.swp
 pp_widget.php
+**/testing

--- a/css/pp-webservices-style.css
+++ b/css/pp-webservices-style.css
@@ -27,6 +27,11 @@
     height: 400px;
 }
 
+.view-animal-video {
+  width: 480px;
+  height: 270px;
+}
+
 .animal-picture {
     width: 175px !important;
     height: 175px !important;

--- a/js/view_animal.js
+++ b/js/view_animal.js
@@ -134,6 +134,9 @@ function load_photo(photo_url) {
     var image_element = jQuery('#animal-picture');
     var loading_spinner = jQuery('.loading');
     image_element.attr('src', photo_url);
+    //Hide video element and show image element
+    jQuery('#animal-video').attr('style', 'display: none');
+    image_element.attr('style', 'display: block');
     image_element.each(function() {
        if(!this.complete) { //Check if image is cached, run animation if it's not.
             image_element.css('opacity', 0.3); //Dim the background image
@@ -146,6 +149,15 @@ function load_photo(photo_url) {
     });
 }
 
+//Add function to load YouTube embed for video
+function load_video(video_id) {
+    var video_element = jQuery('#animal-video');
+    video_element.attr('src', 'https://www.youtube-nocookie.com/embed/'+video_id);
+    //Hide image element and show video element
+    jQuery('#animal-picture').attr('style', 'display: none');
+    video_element.attr('style', 'display: block');
+}
+
 function setup_photo(output_area, animal_details) {
     var animal_picture_container_node = 
             create_html_node('div', [ {name:'class',  value: 'animal-picture-container'} ], output_area, [
@@ -153,6 +165,15 @@ function setup_photo(output_area, animal_details) {
                 create_html_node('img', [ {name: 'class', value: 'view-animal-picture'},
                                           {name: 'id',    value: 'animal-picture'},
                                           {name: 'src',   value: animal_details['Photo1']}]),
+                //Add YouTube embed iframe which is hidden by default. The attributes from width on are from the generated html embed, and might need to be adjusted.
+                create_html_node('iframe', [ {name: 'class', value: 'view-animal-video'},
+                                             {name: 'id', value: 'animal-video'},
+                                             {name: 'style', value: 'display: none'},
+                                             {name: 'width', value: '480'},
+                                             {name: 'height', value: '270'},
+                                             {name: 'title', value: 'YouTube video player'},
+                                             {name: 'frameborder', value: '0'},
+                                             {name: 'allow', value: 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'}]),
                 create_html_node('div', [ {name: 'id', value: 'photo-links'} ]) 
             ]);
 
@@ -165,6 +186,9 @@ function setup_photo_links(animal_details) {
     //Count the number of photo entries (Regex catches all Photo nodes with a link inside them, if it has no link, then it's a blank photo)
     var photo_regex = /"Photo[1-9]{1}":"http:/g;
     var num_of_photos = JSON.stringify(animal_details).match(photo_regex).length;
+
+    //Get video id if it exists for YouTube video embed
+    var video_id = animal_details['VideoID'];
 
     //Create a button node for each picture, and add an event listener to fire when that button is clicked. 
      for(i=0; i<num_of_photos; i++) {
@@ -181,9 +205,27 @@ function setup_photo_links(animal_details) {
             jQuery('#photo1').addClass('active');
         }
 
-        //Finally, add an event listener to switch to the picture when it's button is clicked (using load_photo).
+        //Finally, add an event listener to switch to the picture when its button is clicked (using load_photo).
         picture_element.addEventListener("click", load_photo.bind(null, photo_url));
         jQuery('#photo'+photo_num).click(function() {
+            jQuery('.active').removeClass('active');
+            jQuery(this).addClass('active');
+        });
+    }
+
+    //Create a button node for the video, if it exists, and add an event listener to fire when that button is clicked.
+    if (video_id) {
+        //Use the last photo_num to put video at the end of the photos
+        var video_position = photo_num+1;
+        var video_element = create_html_node('input', [ {name: 'type', value: 'button'},
+                                            {name: 'id', value: 'video'},
+                                            {name: 'class', value: 'photo-btb btn btn-primary btn-sm'},
+                                            {name: 'value', value: video_position}],
+                                        photo_output_area);
+        
+        //Finally, add an event listener to switch to the video when its button is clicked (using load_video).
+        video_element.addEventListener("click", load_video.bind(null, video_id));
+        jQuery('#video').click(function() {
             jQuery('.active').removeClass('active');
             jQuery(this).addClass('active');
         });


### PR DESCRIPTION
I am proposing these additions to view_animal.js (and a small css formatting addition) to resolve #10 

### Change Description
The PetPoint/Petango webservices response includes a video ID that can be used to access the YouTube video of an animal added to PetPoint. Using the same logic that adds the photos and creates the numbered buttons to toggle between them, we can add a 'tab' for the video, if one exists. 

The biggest change is the addition of an iframe element to the picture display area which is used to display the video. Both the img and iframe elements are added in the setup_photo function, but the iframe is hidden at first. When toggling between pictures and the video, the img element is hidden and the iframe one shown, and vice versa.

### Some Comments/Disclaimer About Testing
I am a JavaScript/web-development novice, and am attempting these additions because our shelter wants to be able to display animal videos on our website. We use this plugin and would like to add this functionality without overhauling how we display available animals. 

I am entirely unfamiliar with PHP and don't know how to safely test my changes in a WordPress environment, so I had to put together a modified test of just the view_animal functions as a proof of concept for myself. We may be able to work with our partners to properly test out the changes, but any testing/review you'd be able to do with this pull request would be greatly appreciated! My isolated proof of concept test worked, but I don't know yet if this works in full WordPress context.